### PR TITLE
Add plugin main class to XmlReadWrite eaxmple

### DIFF
--- a/xml-read-write-transform/pom.xml
+++ b/xml-read-write-transform/pom.xml
@@ -23,6 +23,13 @@
                     <licenseResolver>${project.baseUri}../license</licenseResolver>
                 </configuration>
             </plugin>
+             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>org.smooks.examples.xmlrwtransform.Main</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
trying to run it with mvn exec:java fails until I modify pom.xml to add:

<plugin>
    <groupId>org.codehaus.mojo</groupId>
    <artifactId>exec-maven-plugin</artifactId>
    <version>1.6.0</version>
    <executions>
        <execution>
            <goals>
                <goal>java</goal>
            </goals>
        </execution>
    </executions>
    <configuration>
        <mainClass>org.smooks.examples.java2xml.Main</mainClass>
    </configuration>
</plugin>